### PR TITLE
Fix wrong last spin value

### DIFF
--- a/wheel_of_luck.py
+++ b/wheel_of_luck.py
@@ -222,8 +222,7 @@ while True:
         wanted_games_ui_texts, wanted_games = remove_unwated_games(games_ui_texts, games, main_window, event)
         rolled_game = spin_wheel(wanted_games_ui_texts, wanted_games)
         button = event
+        insert_last_spin_into_database(button, rolled_game.Get())
         continue
-
     # Window closing event
-    insert_last_spin_into_database(button, rolled_game.Get())
     break


### PR DESCRIPTION
- When there was no spin and the window was closed, then there was a wrong data inserted into the DB having last_spin category as NULL
- Now the DB last spin insertion works as intending, having moved the last_spin insert to the actual end of the wheel spin.