### PR TITLE
Add a feedback element to the linter outputs

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Check pylint score
       run: |
-        threshold=9.0  # Set your desired threshold here
+        threshold=7.0  # Set your desired threshold here
         score=${{ steps.get_score.outputs.score }}
         if (( $(echo "$score < $threshold" | bc -l) )); then
           echo "Pylint score ($score) is below threshold ($threshold)."

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Extract pylint score
       id: get_score
       run: |
-        score=$(grep -oP 'rated at \K[0-9]+\.[0-9]+' pylint_output.txt)
+        score=$(grep -oP 'rated at \K[0-9]+\.[0-9]+' lint.txt)
         echo "Pylint score is $score"
         echo "::set-output name=score::$score"
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,6 +30,22 @@ jobs:
     - name: CAT output
       run: cat lint.txt
 
+    - name: Extract pylint score
+      id: get_score
+      run: |
+        score=$(grep -oP 'rated at \K[0-9]+\.[0-9]+' pylint_output.txt)
+        echo "Pylint score is $score"
+        echo "::set-output name=score::$score"
+
+    - name: Check pylint score
+      run: |
+        threshold=9.0  # Set your desired threshold here
+        score=${{ steps.get_score.outputs.score }}
+        if (( $(echo "$score < $threshold" | bc -l) )); then
+          echo "Pylint score ($score) is below threshold ($threshold)."
+          exit 1
+        fi
+
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Linter now fails the QA step if the score is below a certain score (set to 7.0 for now) - this will add reliable checks to merge requests, giving warning when contribution breaks conventional code practices *too heavily* .