### PR TITLE
Bugfix/suppress import errors

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Check pylint score
       run: |
-        threshold=7.0  # Set your desired threshold here
+        threshold=8.0  # Set your desired threshold here
         score=${{ steps.get_score.outputs.score }}
         if (( $(echo "$score < $threshold" | bc -l) )); then
           echo "Pylint score ($score) is below threshold ($threshold)."

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --output=lint.txt || true
+        pylint $(git ls-files '*.py') --disable=E0401 --output=lint.txt || true
 
     - name: CAT output
       run: cat lint.txt


### PR DESCRIPTION
I did some research concerning the Linter behavior in terms of E0401 relating to imporing packages and modules. 

Apparently the Python linter (unsuprisingly) struggles with this quite often. 
I suggest disabling it for our purposes as chechking against imports is already done by IDEs locally, thus providing no extra informational or actionable value.
This significantly improves precision of the linter score as there are currently no issues concerning "weird, unexpected or unsolvable" problems within the codebase. 

To compensate, fail threshold has been raised by one point, codebase can clearly afford it (thanks to huge refactor by @Teg3z ).