### PR TITLE
Feature/improve date for db

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -54,7 +54,7 @@ def get_last_spin_string(db):
     formatted_time = entry['last_game_date'].strftime("%d/%m/%Y %H:%M:%S")
 
     return entry['last_category'] + " - " + entry['last_game'] + \
-        " [" + str(formatted_time) + "]"
+        " [" + formatted_time + "]"
 
 def update_last_spin(db, game, category = None, players = None):
     """

--- a/db_handler.py
+++ b/db_handler.py
@@ -51,8 +51,10 @@ def get_last_spin_string(db):
     """
     collection = db['LastSpin']
     entry = collection.find_one()
+    formatted_time = entry['last_game_date'].strftime("%d/%m/%Y %H:%M:%S")
+
     return entry['last_category'] + " - " + entry['last_game'] + \
-        " [" + entry['last_game_date'] + "]"
+        " [" + str(formatted_time) + "]"
 
 def update_last_spin(db, game, category = None, players = None):
     """
@@ -82,7 +84,7 @@ def update_last_spin(db, game, category = None, players = None):
         None
     """
     # Create the time of the spin
-    time = datetime.today().strftime("%d/%m/%Y %H:%M:%S")
+    time = datetime.now()
 
     # Select the correct collection from the DB and create the new data values to enter
     if players is not None:


### PR DESCRIPTION
To complete the list of @R4tmax's suggestions from our code review I have changed the date format from a string to a datetime object, that is more efficient in databases.

Its efficient format, but not pretty, so now the code converts the datetime object from db to a nice string date format.

I have also made a new "Logs" collection in MongoDB and moved all documents across all Logs* collections into it. The moved documents have the property `game_time` adjusted to a datetime object from string to keep consistency and also a new property called `players`, that being a list of players who played the game in the document, basically converted category (LogsDK -> new document with players: ['D', 'K'], D and K being discord names of the players).