### PR TITLE
Bugfix/improve cx freeze implementation

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -31,7 +31,6 @@ jobs:
         touch variables.env
         ls .
         python setup.py bdist_appimage
-        python setup.py bdist_rpm
         python setup.py bdist_deb
 
     - name: Validate directory contents
@@ -42,13 +41,6 @@ jobs:
       with:
         path: dist/*.AppImage
         name: WoL.AppImage
-        overwrite: true
-
-    - name: Upload rpm
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/*.rpm
-        name: WoL.rpm
         overwrite: true
 
     - name: Upload deb
@@ -67,11 +59,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: ./artifacts
-
-    - name: Upload rpm to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: artifacts/*.rpm
 
     - name: Upload APP to Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: dist/*.app
+          path: ./build/dist/*.app
           name: WoL.app
           overwrite: true
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -2,7 +2,7 @@ name: Build_and_Release_Packages
 
 on:
   release:
-    types: [published]
+    types: [published,edited]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.8'
         cache: 'pip'
         cache-dependency-path: './requirements.txt'
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -33,8 +33,6 @@ jobs:
         touch variables.env
         ls .
         python setup.py build
-        ls ./dist
-        ls ./build
 
     - name: Validate dist folder
       run: ls ./dist && ls ./build

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.10'
         cache: 'pip'
         cache-dependency-path: './requirements.txt'
 
@@ -31,10 +31,8 @@ jobs:
     - name: Build packages
       run: |
         touch variables.env
-        rpm --version
         ls .
-        python setup.py build
-        python setup.py bdist_rpm
+        python setup.py bdist_appimage
 
     - name: Validate directory contents
       run: ls .

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -20,19 +20,19 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
+    - name: Build dependencies and packages
       run: |
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
-
-    - name: Build packages
-      run: |
         python setup.py bdist_msi
         python setup.py bdist_mac
         python setup.py bdist_deb
         python setup.py bdist_rpm
-        ls dist
+        ls ./dist
+
+    - name: Validate dist folder
+      run: ls ./dist
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -38,7 +38,7 @@ jobs:
       run: ls .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: dist/*
 
@@ -51,6 +51,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: ./artifacts
+        overwrite: true
 
     - name: Upload MSI to Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
+        ls .
         python setup.py build
         ls ./dist
         ls ./build

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -26,10 +26,6 @@ jobs:
         pip install cx_Freeze 
         pip install -r requirements.txt
         python setup.py build
-#       python setup.py bdist_msi
-#       python setup.py bdist_mac
-#       python setup.py bdist_deb
-#       python setup.py bdist_rpm
         ls ./dist
         ls ./build
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -26,9 +26,9 @@ jobs:
         pip install cx_Freeze 
         pip install -r requirements.txt
         python setup.py build
-#        python setup.py bdist_msi
+#       python setup.py bdist_msi
 #       python setup.py bdist_mac
-#        python setup.py bdist_deb
+#       python setup.py bdist_deb
 #       python setup.py bdist_rpm
         ls ./dist
         ls ./build

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -41,6 +41,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         path: dist/*
+        overwrite: true
 
   release:
     needs: build
@@ -51,7 +52,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: ./artifacts
-        overwrite: true
+
 
     - name: Upload MSI to Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -95,7 +95,7 @@ jobs:
           overwrite: true
 
   release-msi:
-    needs: build-appimage
+    needs: build-msi
     runs-on: ubuntu-latest
 
     steps:
@@ -146,7 +146,7 @@ jobs:
           overwrite: true
 
   release-dmg:
-    needs: build-appimage
+    needs: build-dmg
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
-        touch variables.txt
+        touch variables.env
         ls .
         python setup.py build
         ls ./dist

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-appimage:
+  build-linux-packages:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,19 +31,35 @@ jobs:
         touch variables.env
         ls .
         python setup.py bdist_appimage
+        python setup.py bdist_rpm
+        python setup.py bdist_deb
 
     - name: Validate directory contents
       run: ls .
 
-    - name: Upload artifacts
+    - name: Upload AppImage
       uses: actions/upload-artifact@v4
       with:
-        path: dist/*
-        name: WoL.app
+        path: dist/*.AppImage
+        name: WoL.AppImage
         overwrite: true
 
-  release-appimage:
-    needs: build-appimage
+    - name: Upload rpm
+      uses: actions/upload-artifact@v4
+      with:
+        path: dist/*.rpm
+        name: WoL.rpm
+        overwrite: true
+
+    - name: Upload deb
+      uses: actions/upload-artifact@v4
+      with:
+        path: dist/*.deb
+        name: WoL.deb
+        overwrite: true
+
+  release-linux-packages:
+    needs: build-linux-packages
     runs-on: ubuntu-latest
 
     steps:
@@ -52,10 +68,20 @@ jobs:
       with:
         path: ./artifacts
 
+    - name: Upload rpm to Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: artifacts/*.rpm
+
     - name: Upload APP to Release
       uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/*.app
+        files: artifacts/*.AppImage
+
+    - name: Upload deb to Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: artifacts/*.deb
 
   build-msi:
     runs-on: windows-latest
@@ -93,3 +119,38 @@ jobs:
           name: WoL.msi
           overwrite: true
 
+  build-dmg:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: './requirements.txt'
+
+      - name: Build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cx_Freeze 
+          pip install -r requirements.txt
+
+      - name: Build packages
+        run: |
+          touch variables.env
+          ls .
+          python setup.py bdist_dmg
+
+      - name: Validate directory contents
+        run: ls .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/*
+          name: WoL.dmg
+          overwrite: true

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux-packages:
+  build-appimage:
     runs-on: ubuntu-latest
 
     steps:
@@ -94,6 +94,21 @@ jobs:
           name: WoL.msi
           overwrite: true
 
+  release-msi:
+    needs: build-appimage
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: ./artifacts
+
+    - name: Upload APP to Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: artifacts/*.msi
+
   build-dmg:
     runs-on: macos-latest
 
@@ -129,3 +144,18 @@ jobs:
           path: dist/*.dmg
           name: WoL.dmg
           overwrite: true
+
+  release-dmg:
+    needs: build-appimage
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: ./artifacts
+
+    - name: Upload APP to Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: artifacts/*.dmg

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -34,8 +34,8 @@ jobs:
         ls .
         python setup.py build
 
-    - name: Validate dist folder
-      run: ls ./dist && ls ./build
+    - name: Validate directory contents
+      run: ls .
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: './requirements.txt'
 
     - name: Build dependencies and packages
       run: |

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -135,7 +135,9 @@ jobs:
           python setup.py bdist_dmg
 
       - name: Validate directory contents
-        run: ls . && ls ./build/dist
+        run: |
+          ls .
+          ls ./build/dist
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,14 +25,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
-        python setup.py bdist_msi
-        python setup.py bdist_mac
-        python setup.py bdist_deb
-        python setup.py bdist_rpm
+        python setup.py build
+#        python setup.py bdist_msi
+#       python setup.py bdist_mac
+#        python setup.py bdist_deb
+#       python setup.py bdist_rpm
         ls ./dist
+        ls ./build
 
     - name: Validate dist folder
-      run: ls ./dist
+      run: ls ./dist && ls ./build
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -135,7 +135,7 @@ jobs:
           python setup.py bdist_dmg
 
       - name: Validate directory contents
-        run: ls .
+        run: ls . && ls ./build/dist
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,10 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
-        rpm --version
-        sudo apt-get install alien
-        sudo apt-get install fakeroot
-        
 
     - name: Build packages
       run: |
@@ -47,15 +43,8 @@ jobs:
         name: WoL.AppImage
         overwrite: true
 
-    - name: Upload deb
-      uses: actions/upload-artifact@v4
-      with:
-        path: dist/*.deb
-        name: WoL.deb
-        overwrite: true
-
-  release-linux-packages:
-    needs: build-linux-packages
+  release-appimage:
+    needs: build-appimage
     runs-on: ubuntu-latest
 
     steps:
@@ -68,11 +57,6 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: artifacts/*.AppImage
-
-    - name: Upload deb to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: artifacts/*.deb
 
   build-msi:
     runs-on: windows-latest
@@ -142,6 +126,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: dist/*
+          path: dist/*.dmg
           name: WoL.dmg
           overwrite: true

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -33,6 +33,7 @@ jobs:
         touch variables.env
         ls .
         python setup.py build
+        python setup.py bdist_rpm
 
     - name: Validate directory contents
       run: ls .

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -135,15 +135,14 @@ jobs:
           python setup.py bdist_dmg
 
       - name: Validate directory contents
-        run: |
-          ls .
-          ls ./build/dist
+        run: ls .
+
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          path: dist/*.dmg
-          name: WoL.dmg
+          path: dist/*.app
+          name: WoL.app
           overwrite: true
 
   release-dmg:
@@ -159,4 +158,4 @@ jobs:
     - name: Upload APP to Release
       uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/*.dmg
+        files: artifacts/*.app

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -22,11 +22,14 @@ jobs:
         cache: 'pip'
         cache-dependency-path: './requirements.txt'
 
-    - name: Build dependencies and packages
+    - name: Build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
+
+    - name: Build packages
+      run: |
         touch variables.env
         ls .
         python setup.py build

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -5,10 +5,8 @@ on:
     types: [published]
   workflow_dispatch:
 
-
-
 jobs:
-  build:
+  build-appimage:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,10 +39,11 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         path: dist/*
+        name: WoL.app
         overwrite: true
 
-  release:
-    needs: build
+  release-appimage:
+    needs: build-appimage
     runs-on: ubuntu-latest
 
     steps:
@@ -53,27 +52,44 @@ jobs:
       with:
         path: ./artifacts
 
-
-    - name: Upload MSI to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: artifacts/*.msi
-
-
     - name: Upload APP to Release
       uses: softprops/action-gh-release@v2
       with:
         files: artifacts/*.app
 
+  build-msi:
+    runs-on: windows-latest
 
-    - name: Upload DEB to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: artifacts/*.deb
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: './requirements.txt'
 
-    - name: Upload RPM to Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: artifacts/*.rpm
+      - name: Build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cx_Freeze 
+          pip install -r requirements.txt
+
+      - name: Build packages
+        run: |
+          touch variables.env
+          ls .
+          python setup.py bdist_msi
+
+      - name: Validate directory contents
+        run: ls .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/*
+          name: WoL.msi
+          overwrite: true
 

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Build packages
       run: |
         touch variables.env
+        rpm --version
         ls .
         python setup.py build
         python setup.py bdist_rpm

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -26,8 +26,8 @@ jobs:
         pip install cx_Freeze 
         pip install -r requirements.txt
         rpm --version
-        apt-get install alien
-        apt-get install fakeroot
+        sudo apt-get install alien
+        sudo apt-get install fakeroot
         
 
     - name: Build packages

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -31,7 +31,6 @@ jobs:
         touch variables.env
         ls .
         python setup.py bdist_appimage
-        python setup.py bdist_deb
 
     - name: Validate directory contents
       run: ls .

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,6 +25,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
+        rpm --version
+        apt-get install alien
+        apt-get install fakeroot
+        
 
     - name: Build packages
       run: |

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install cx_Freeze 
         pip install -r requirements.txt
+        touch variables.txt
         ls .
         python setup.py build
         ls ./dist

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -54,25 +54,25 @@ jobs:
         overwrite: true
 
     - name: Upload MSI to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/MSI/*.msi
-      if: steps.download.outputs.found
+        files: artifacts/*.msi
+
 
     - name: Upload APP to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/APP/*.app
-      if: steps.download.outputs.found
+        files: artifacts/*.app
+
 
     - name: Upload DEB to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/DEB/*.deb
-      if: steps.download.outputs.found
+        files: artifacts/*.deb
+
 
     - name: Upload RPM to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
-        files: artifacts/RPM/*.rpm
-      if: steps.download.outputs.found
+        files: artifacts/*.rpm
+

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,11 @@ executables = [
 setup(name='WheelOfLuck',
       version = '2.0.1',
       description = 'Interactive handler for Discord based solution of a game to play in a group',
-      options = {'build_exe': build_options},
+      options = {
+          'build_exe': build_options,
+          'bdist_rpm': {
+              'release': '1',  # Control the release number here
+              'packager': 'Martin @R4tmax Kadlec kadlec.m.90@gmail.com',
+          }
+      },
       executables = executables)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from cx_Freeze import setup, Executable
-import sys
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
@@ -8,10 +7,10 @@ build_options = {'packages': ['dns','dns.resolver','dns.rdatatype'],
                  'include_files': [('variables.env', 'variables.env')]
                  }
 
-base = "gui"
+BASE = "gui"
 
 executables = [
-    Executable('wheel_of_luck.py', base=base)
+    Executable('wheel_of_luck.py', base=BASE)
 ]
 
 setup(name='WheelOfLuck',

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,6 @@ setup(name='WheelOfLuck',
       version = '2.0.1',
       description = 'Interactive handler for Discord based solution of a game to play in a group',
       options = {
-          'build_exe': build_options,
-          'bdist_rpm': {
-              'release': '1',  # Control the release number here
-              'packager': 'Martin @R4tmax Kadlec kadlec.m.90@gmail.com',
-          }
-      },
+          'build_exe': build_options
+     },
       executables = executables)


### PR DESCRIPTION
Provides secondbatches of fixes for #31 , there is a lot of details to dive into, so just an overview here

I have some issues with how the cx_freeze lib does things. 
I will test the approaches on my VM some other day, It might be possible that the best approach might be just using .zip files

TLDR: Linux builds are mostly broken, Mac OS artifact is laughably bloated, RPM and DEB builds break the versioning syntax - gotta love Python

Workflow now runs 3 pararel jobs for each supported O, builds its respective filetype, uploads it via artefact system and then calls a hook to attach itself to GH release, take note that the "second" part of the WF only works when attached to git pushes with git tags (this is done automatically on GH release, BUT does not allow builds for manual dispatch, this is actually a good thing becuase it allows for testing of the pipeline without actually commiting artifacts outside of the action ecosystem. 

Furthermore, I added overwrite directive to uploads to prevent bloat of diskspace and caching of pip for python setups to cut time on dependency builds. 

Appologies for the bloated commit log, this is just how GH actions need to be developed and tested I suppose